### PR TITLE
new parsers for Reactome source

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
@@ -128,7 +128,7 @@ sub load_checksum {
     $file =~ s/\n//;
     if ($file =~ /checksum/) { next; }
     my $input_file = catfile($checksum_dir, $file);
-    my $input_fh = XrefParser::BaseParser->get_filehandle($input_file);
+    my $input_fh = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->get_filehandle($input_file);
     while(my $line = <$input_fh>) {
       chomp $line;
       my ($id, $checksum) = split(/\s+/, $line);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -95,15 +95,15 @@
       "priority" : 2
     },
     {
-      "name" : "Reactome",
-      "parser" : "ReactomeParser",
+      "name" : "Reactome_gene",
+      "parser" : "ReactomeDirectParser",
       "file" : "http://www.reactome.org/download/current/Ensembl2Reactome_All_Levels.txt",
       "release" : "http://www.reactome.org/ReactomeRESTfulAPI/RESTfulWS/version",
       "priority" : 1
     },
     {
-      "name" : "Reactome",
-      "parser" : "ReactomeParser",
+      "name" : "Reactome_translation",
+      "parser" : "ReactomeUniProtParser",
       "file" : "http://www.reactome.org/download/current/UniProt2Reactome_All_Levels.txt",
       "release" : "http://www.reactome.org/ReactomeRESTfulAPI/RESTfulWS/version",
       "priority" : 2


### PR DESCRIPTION
The Reactome Parser code has been ported to ensembl-xref as two separate parsers, to deal with two different files
The update to the config file reflects this